### PR TITLE
Allow uneven number of physical and virtual qubits

### DIFF
--- a/qiskit_bip_mapper/bip_mapping.py
+++ b/qiskit_bip_mapper/bip_mapping.py
@@ -188,12 +188,14 @@ class BIPMapping(TransformationPass):
             raise TranspilerError(
                 "Insufficient number of physical qubits. "
                 "BIPMapping requires the number of physical qubits to be equal "
-                 "or exceed the number of virtual qubits."
+                "or exceed the number of virtual qubits."
             )
 
         # Add dummy variables to dag so physical qubits = virtual qubits.
         if len(self.qubit_subset) > len(dag.qubits):
-            dag.add_qreg(QuantumRegister(size=(len(self.qubit_subset) - len(dag.qubits)), name="dummy"))
+            dag.add_qreg(
+                QuantumRegister(size=(len(self.qubit_subset) - len(dag.qubits)), name="dummy")
+            )
 
         disjoint_utils.require_layout_isolated_to_component(
             dag, self.coupling_map if self.target is None else self.target

--- a/qiskit_bip_mapper/bip_mapping.py
+++ b/qiskit_bip_mapper/bip_mapping.py
@@ -190,7 +190,7 @@ class BIPMapping(TransformationPass):
                 "BIPMapping requires the number of physical qubits to be equal "
                  "or exceed the number of virtual qubits."
             )
-        
+
         # Add dummy variables to dag so physical qubits = virtual qubits.
         if len(self.qubit_subset) > len(dag.qubits):
             dag.add_qreg(QuantumRegister(size=(len(self.qubit_subset) - len(dag.qubits)), name="dummy"))

--- a/qiskit_bip_mapper/bip_mapping.py
+++ b/qiskit_bip_mapper/bip_mapping.py
@@ -168,7 +168,7 @@ class BIPMapping(TransformationPass):
         """Run the BIPMapping pass on ``dag``.
 
         Run the BIPMapping pass on `dag, assuming the number of virtual qubits (defined in
-        `dag`) and the number of physical qubits (defined in `coupling_map`) are the same.
+        `dag`) is less than or equal to the number of physical qubits (defined in `coupling_map`).
 
         Args:
             dag (DAGCircuit): DAG to map.
@@ -178,20 +178,23 @@ class BIPMapping(TransformationPass):
                 returns the original dag.
 
         Raises:
-            TranspilerError: if the number of virtual and physical qubits are not the same.
+            TranspilerError: if the number of virtual qubits exeeds physical qubits.
             AssertionError: if the final layout is not valid.
         """
         if self.coupling_map is None:
             return dag
 
-        if len(dag.qubits) > len(self.qubit_subset):
-            raise TranspilerError("More virtual qubits exist than physical qubits.")
-
-        if len(dag.qubits) != len(self.qubit_subset):
+        if len(self.qubit_subset) < len(dag.qubits):
             raise TranspilerError(
-                "BIPMapping requires the number of virtual and physical qubits to be the same. "
-                "Supply 'qubit_subset' to specify physical qubits to use."
+                "Insufficient number of physical qubits. "
+                "BIPMapping requires the number of physical qubits to be equal "
+                 "or exceed the number of virtual qubits."
             )
+        
+        # Add dummy variables to dag so physical qubits = virtual qubits.
+        if len(self.qubit_subset) > len(dag.qubits):
+            dag.add_qreg(QuantumRegister(size=(len(self.qubit_subset) - len(dag.qubits)), name="dummy"))
+
         disjoint_utils.require_layout_isolated_to_component(
             dag, self.coupling_map if self.target is None else self.target
         )

--- a/qiskit_bip_mapper/bip_model.py
+++ b/qiskit_bip_mapper/bip_model.py
@@ -95,9 +95,9 @@ class BIPMappingModel:
         self.num_pqubits = self._coupling.size()
         self._arcs = self._coupling.get_edges()
 
-        if self.num_vqubits != self.num_pqubits:
+        if self.num_vqubits > self.num_pqubits:
             raise TranspilerError(
-                "BIPMappingModel assumes the same size of virtual and physical qubits."
+                "BIPMappingModel assumes the number of virtual qubits <= physical qubits."
             )
 
         self._index_to_virtual = dict(enumerate(dag.qubits))

--- a/qiskit_bip_mapper/tests/test_bip_mapping.py
+++ b/qiskit_bip_mapper/tests/test_bip_mapping.py
@@ -267,7 +267,7 @@ class TestBIPMapping(unittest.TestCase):
         circuit.cx(0, 1)
         circuit.cx(2, 3)
         circuit.cx(0, 3)
-        
+
         property_set = {}
         coupling = CouplingMap.from_line(5)
         actual = BIPMapping(coupling, objective="depth")(circuit, property_set)

--- a/qiskit_bip_mapper/tests/test_bip_mapping.py
+++ b/qiskit_bip_mapper/tests/test_bip_mapping.py
@@ -267,9 +267,10 @@ class TestBIPMapping(unittest.TestCase):
         circuit.cx(0, 1)
         circuit.cx(2, 3)
         circuit.cx(0, 3)
-
+        
+        property_set = {}
         coupling = CouplingMap.from_line(5)
-        actual = BIPMapping(coupling, objective="depth")(circuit)
+        actual = BIPMapping(coupling, objective="depth")(circuit, property_set)
         self.assertEqual(5, actual.depth())
 
     def test_qubit_subset(self):

--- a/qiskit_bip_mapper/tests/test_bip_mapping.py
+++ b/qiskit_bip_mapper/tests/test_bip_mapping.py
@@ -270,7 +270,7 @@ class TestBIPMapping(unittest.TestCase):
 
         coupling = CouplingMap.from_line(5)
         actual = BIPMapping(coupling, objective="depth")(circuit)
-        self.assertEqual(5, actual.depth)
+        self.assertEqual(5, actual.depth())
 
     def test_qubit_subset(self):
         """Test if `qubit_subset` option works as expected."""

--- a/qiskit_bip_mapper/tests/test_bip_mapping.py
+++ b/qiskit_bip_mapper/tests/test_bip_mapping.py
@@ -270,8 +270,8 @@ class TestBIPMapping(unittest.TestCase):
         circuit.cx(1, 2)
 
         coupling = CouplingMap.from_line(5)
-        with self.assertRaises(TranspilerError):
-            BIPMapping(coupling)(circuit)
+        actual = BIPMapping(coupling)(circuit)
+        self.assertEqual(circuit, actual)
 
     def test_qubit_subset(self):
         """Test if `qubit_subset` option works as expected."""

--- a/qiskit_bip_mapper/tests/test_bip_mapping.py
+++ b/qiskit_bip_mapper/tests/test_bip_mapping.py
@@ -271,7 +271,7 @@ class TestBIPMapping(unittest.TestCase):
         property_set = {}
         coupling = CouplingMap.from_line(5)
         actual = BIPMapping(coupling, objective="depth")(circuit, property_set)
-        self.assertEqual(5, actual.depth())
+        self.assertEqual(2, actual.depth())
 
     def test_qubit_subset(self):
         """Test if `qubit_subset` option works as expected."""

--- a/qiskit_bip_mapper/tests/test_bip_mapping.py
+++ b/qiskit_bip_mapper/tests/test_bip_mapping.py
@@ -267,11 +267,10 @@ class TestBIPMapping(unittest.TestCase):
         circuit.cx(0, 1)
         circuit.cx(2, 3)
         circuit.cx(0, 3)
-        circuit.cx(1, 2)
 
         coupling = CouplingMap.from_line(5)
-        actual = BIPMapping(coupling)(circuit)
-        self.assertEqual(circuit, actual)
+        actual = BIPMapping(coupling, objective="depth")(circuit)
+        self.assertEqual(5, actual.depth)
 
     def test_qubit_subset(self):
         """Test if `qubit_subset` option works as expected."""


### PR DESCRIPTION
As long as the number of physical qubits exceeds the number virtual bits, BIPMapper should run. This is done by adding dummy registers to the circuit until the # virtual bits = # physical bits.